### PR TITLE
fixed building on nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ impl<'a> Block<'a> {
 
     /// Get the pointer from this block.
     pub fn ptr(&self) -> *mut u8 {
-        *self.ptr
+        self.ptr.as_ptr()
     }
     /// Get the size of this block.
     pub fn size(&self) -> usize {


### PR DESCRIPTION
Hi!

Thank you for allocators! 
Please consider merging fix for compilation on nightly-2017-06-08-x86_64

after the fix:
```
➜  allocators git:(7fb0ab3) rustup override add nightly-2017-06-08-x86_64-apple-darwin
info: using existing install for 'nightly-2017-06-08-x86_64-apple-darwin'
info: override toolchain for '/Users/vladimirshakhov/IdeaProjects/allocators' set to 'nightly-2017-06-08-x86_64-apple-darwin'

nightly-2017-06-08-x86_64-apple-darwin unchanged - rustc 1.19.0-nightly (f062832b2 2017-06-07)

➜  allocators git:(7fb0ab3) cargo test
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running target/debug/deps/allocators-f4b307a4ccdeed34
running 13 tests
test scoped::tests::owning ... ok
test scoped::tests::out_of_memory ... ok
test composable::tests::null_allocate ... ok
test scoped::tests::scope_scope ... ok
test tests::boxed_allocator ... ok
test tests::heap_lifetime ... ok
test tests::unsizing ... ok
test scoped::tests::use_outer ... ok
test tests::take_out ... ok
test scoped::tests::mutex_sharing ... ok
test freelist::tests::it_works ... ok
test scoped::tests::placement_in ... ok
test tests::heap_in_place ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out


running 3 tests
test src/lib.rs - Allocator::allocate (line 76) ... ok
test src/lib.rs - Allocator::make_place (line 102) ... ok
test src/lib.rs -  (line 4) ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

```

before:
```


HEAD is now at e2c7582... Merge branch 'master' of https://github.com/rphmeier/allocators
➜  allocators git:(e2c7582) cargo test | pbcopy
   Compiling allocators v0.1.9 (file:///Users/vladimirshakhov/IdeaProjects/allocators)
error: type `std::ptr::Unique<u8>` cannot be dereferenced
   --> src/lib.rs:204:9
    |
204 |         *self.ptr
    |         ^^^^^^^^^

error: type `std::ptr::Unique<T>` cannot be dereferenced
  --> src/boxed.rs:21:45
   |
21 |         let val = unsafe { ::std::ptr::read(*self.item) };
   |                                             ^^^^^^^^^^

error: type `std::ptr::Unique<T>` cannot be dereferenced
  --> src/boxed.rs:22:32
   |
22 |         let block = Block::new(*self.item as *mut u8, self.size, self.align);
   |                                ^^^^^^^^^^

error: type `std::ptr::Unique<T>` cannot be dereferenced
  --> src/boxed.rs:30:20
   |
30 |         Block::new(*self.item as *mut u8, self.size, self.align)
   |                    ^^^^^^^^^^

error: type `std::ptr::Unique<u8>` cannot be dereferenced
   --> src/lib.rs:204:9
    |


```